### PR TITLE
feat: Zigビルド基盤を初期化 (#1)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -26,6 +26,9 @@ pub fn build(b: *std.Build) void {
     const run_step = b.step("run", "Run the application");
     run_step.dependOn(&run_cmd.step);
 
+    // Tests are rooted at src/main.zig which @import's other source files.
+    // When adding tests in separate files, import them from main.zig or add
+    // dedicated addTest targets here to ensure they are picked up by `zig build test`.
     const test_mod = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
         .target = target,

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,43 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const exe_mod = b.createModule(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const exe = b.addExecutable(.{
+        .name = "dkill",
+        .root_module = exe_mod,
+    });
+
+    b.installArtifact(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+
+    const run_step = b.step("run", "Run the application");
+    run_step.dependOn(&run_cmd.step);
+
+    const test_mod = b.createModule(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const exe_unit_tests = b.addTest(.{
+        .root_module = test_mod,
+    });
+
+    const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
+
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_exe_unit_tests.step);
+}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,12 @@
+.{
+    .name = .dkill,
+    .fingerprint = 0x8cfdafe5cbc53e65,
+    .version = "0.1.0",
+    .minimum_zig_version = "0.15.0",
+    .dependencies = .{},
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,14 +1,20 @@
 const std = @import("std");
 
+pub const version = "0.1.0";
+
+fn versionString() []const u8 {
+    return "dkill v" ++ version;
+}
+
 pub fn main() !void {
     var stdout_buffer: [1024]u8 = undefined;
     var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
     const stdout = &stdout_writer.interface;
 
-    try stdout.print("dkill v0.1.0\n", .{});
+    try stdout.print("{s}\n", .{versionString()});
     try stdout.flush();
 }
 
-test "simple test" {
-    try std.testing.expect(true);
+test "version string" {
+    try std.testing.expectEqualStrings("dkill v0.1.0", versionString());
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,0 +1,14 @@
+const std = @import("std");
+
+pub fn main() !void {
+    var stdout_buffer: [1024]u8 = undefined;
+    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
+    const stdout = &stdout_writer.interface;
+
+    try stdout.print("dkill v0.1.0\n", .{});
+    try stdout.flush();
+}
+
+test "simple test" {
+    try std.testing.expect(true);
+}


### PR DESCRIPTION
## 概要

Issue #1 対応: dkill プロジェクトの Zig ビルド基盤を作成しました。

## 変更内容

- `build.zig` — Zig 0.15.2 対応のビルド設定（exe / run / test step）
- `build.zig.zon` — パッケージマニフェスト（name=dkill, version=0.1.0）
- `src/main.zig` — エントリポイントスケルトン（"dkill v0.1.0" 出力）

## 動作確認

- [x] `zig build` が成功する
- [x] `./zig-out/bin/dkill` が `dkill v0.1.0` を出力する
- [x] `zig build test` が成功する

## 確認事項

- [x] Zig 0.15.2 の新API（`root_module`、`std.fs.File.stdout()`）を使用
- [x] `build.zig.zon` に必須の `fingerprint` フィールドを追加
- [x] `.gitignore` に従い `.zig-cache/` と `zig-out/` は除外済み

Closes #1