### PR TITLE
feat: 相対時間ユーティリティを実装 (#3)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -64,4 +64,25 @@ pub fn build(b: *std.Build) void {
 
     const run_size_tests = b.addRunArtifact(size_tests);
     test_step.dependOn(&run_size_tests.step);
+
+    // Time utility tests
+    const time_util_mod = b.createModule(.{
+        .root_source_file = b.path("src/utils/time.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const time_test_mod = b.createModule(.{
+        .root_source_file = b.path("tests/time_test.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    time_test_mod.addImport("../src/utils/time.zig", time_util_mod);
+
+    const time_tests = b.addTest(.{
+        .root_module = time_test_mod,
+    });
+
+    const run_time_tests = b.addRunArtifact(time_tests);
+    test_step.dependOn(&run_time_tests.step);
 }

--- a/src/utils/time.zig
+++ b/src/utils/time.zig
@@ -1,0 +1,28 @@
+const std = @import("std");
+
+/// Unix timestamp を相対時間文字列に変換する。
+/// 例: (now - 5日) → "5 days ago"
+///
+/// buf は最低 32 バイト必要。
+pub fn relativeTime(unix_ts: i64, buf: []u8) []const u8 {
+    std.debug.assert(buf.len >= 32);
+
+    const now = std.time.timestamp();
+    const diff = now - unix_ts;
+
+    if (diff < 60) {
+        return "just now";
+    } else if (diff < 3600) {
+        const minutes = @divFloor(diff, 60);
+        return std.fmt.bufPrint(buf, "{d} minutes ago", .{minutes}) catch unreachable;
+    } else if (diff < 86400) {
+        const hours = @divFloor(diff, 3600);
+        return std.fmt.bufPrint(buf, "{d} hours ago", .{hours}) catch unreachable;
+    } else if (diff < 2592000) {
+        const days = @divFloor(diff, 86400);
+        return std.fmt.bufPrint(buf, "{d} days ago", .{days}) catch unreachable;
+    } else {
+        const months = @divFloor(diff, 2592000);
+        return std.fmt.bufPrint(buf, "{d} months ago", .{months}) catch unreachable;
+    }
+}

--- a/src/utils/time.zig
+++ b/src/utils/time.zig
@@ -14,15 +14,23 @@ pub fn relativeTime(unix_ts: i64, buf: []u8) []const u8 {
         return "just now";
     } else if (diff < 3600) {
         const minutes = @divFloor(diff, 60);
-        return std.fmt.bufPrint(buf, "{d} minutes ago", .{minutes}) catch unreachable;
+        const s: []const u8 = if (minutes == 1) "" else "s";
+        return std.fmt.bufPrint(buf, "{d} minute{s} ago", .{ minutes, s }) catch unreachable;
     } else if (diff < 86400) {
         const hours = @divFloor(diff, 3600);
-        return std.fmt.bufPrint(buf, "{d} hours ago", .{hours}) catch unreachable;
+        const s: []const u8 = if (hours == 1) "" else "s";
+        return std.fmt.bufPrint(buf, "{d} hour{s} ago", .{ hours, s }) catch unreachable;
     } else if (diff < 2592000) {
         const days = @divFloor(diff, 86400);
-        return std.fmt.bufPrint(buf, "{d} days ago", .{days}) catch unreachable;
-    } else {
+        const s: []const u8 = if (days == 1) "" else "s";
+        return std.fmt.bufPrint(buf, "{d} day{s} ago", .{ days, s }) catch unreachable;
+    } else if (diff < 31536000) {
         const months = @divFloor(diff, 2592000);
-        return std.fmt.bufPrint(buf, "{d} months ago", .{months}) catch unreachable;
+        const s: []const u8 = if (months == 1) "" else "s";
+        return std.fmt.bufPrint(buf, "{d} month{s} ago", .{ months, s }) catch unreachable;
+    } else {
+        const years = @divFloor(diff, 31536000);
+        const s: []const u8 = if (years == 1) "" else "s";
+        return std.fmt.bufPrint(buf, "{d} year{s} ago", .{ years, s }) catch unreachable;
     }
 }

--- a/tests/time_test.zig
+++ b/tests/time_test.zig
@@ -8,6 +8,13 @@ test "just now" {
     try std.testing.expectEqualStrings("just now", time.relativeTime(ts, &buf));
 }
 
+test "1 minute ago (singular)" {
+    var buf: [32]u8 = undefined;
+    const now = std.time.timestamp();
+    const ts = now - 60; // 1分前
+    try std.testing.expectEqualStrings("1 minute ago", time.relativeTime(ts, &buf));
+}
+
 test "2 minutes ago" {
     var buf: [32]u8 = undefined;
     const now = std.time.timestamp();
@@ -34,4 +41,18 @@ test "2 months ago" {
     const now = std.time.timestamp();
     const ts = now - (60 * 86400); // 60日前 = 約2ヶ月
     try std.testing.expectEqualStrings("2 months ago", time.relativeTime(ts, &buf));
+}
+
+test "1 year ago (singular)" {
+    var buf: [32]u8 = undefined;
+    const now = std.time.timestamp();
+    const ts = now - (365 * 86400); // 365日前
+    try std.testing.expectEqualStrings("1 year ago", time.relativeTime(ts, &buf));
+}
+
+test "2 years ago" {
+    var buf: [32]u8 = undefined;
+    const now = std.time.timestamp();
+    const ts = now - (730 * 86400); // 730日前
+    try std.testing.expectEqualStrings("2 years ago", time.relativeTime(ts, &buf));
 }

--- a/tests/time_test.zig
+++ b/tests/time_test.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+const time = @import("../src/utils/time.zig");
+
+test "just now" {
+    var buf: [32]u8 = undefined;
+    const now = std.time.timestamp();
+    const ts = now - 30; // 30秒前
+    try std.testing.expectEqualStrings("just now", time.relativeTime(ts, &buf));
+}
+
+test "2 minutes ago" {
+    var buf: [32]u8 = undefined;
+    const now = std.time.timestamp();
+    const ts = now - 120; // 2分前
+    try std.testing.expectEqualStrings("2 minutes ago", time.relativeTime(ts, &buf));
+}
+
+test "3 hours ago" {
+    var buf: [32]u8 = undefined;
+    const now = std.time.timestamp();
+    const ts = now - (3 * 3600); // 3時間前
+    try std.testing.expectEqualStrings("3 hours ago", time.relativeTime(ts, &buf));
+}
+
+test "5 days ago" {
+    var buf: [32]u8 = undefined;
+    const now = std.time.timestamp();
+    const ts = now - (5 * 86400); // 5日前
+    try std.testing.expectEqualStrings("5 days ago", time.relativeTime(ts, &buf));
+}
+
+test "2 months ago" {
+    var buf: [32]u8 = undefined;
+    const now = std.time.timestamp();
+    const ts = now - (60 * 86400); // 60日前 = 約2ヶ月
+    try std.testing.expectEqualStrings("2 months ago", time.relativeTime(ts, &buf));
+}


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## レビューに関して
レビューする際には、以下のprefix(接頭辞)を付けましょう。
[must] → かならず変更してね
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)
[nits] → ささいな指摘(nitpick)
[ask] → 質問
[fyi] → 参考情報

## Issues No
close #3

## 概要
Docker リソースの作成日時（Unix timestamp）を "3 days ago" のような相対表示に変換する `relativeTime` 関数を実装しました。

## 変更内容
### 追加機能
- [x] `src/utils/time.zig` — Unix timestamp → 相対時間文字列変換
- [x] `tests/time_test.zig` — 5つのテストケース（TDD）
- [x] `build.zig` — time utility テストステップを追加

### 修正内容
- [ ] バグ修正A
- [ ] バグ修正B

### その他の変更
- [ ] リファクタリング
- [ ] ドキュメント更新
- [x] テスト追加

## 動作確認手順
1. 環境構築
   ```bash
   # 不要（ライブラリのみ）
   ```

2. 確認手順
   - [x] 手順1: `zig build test --summary all` で全テスト通過を確認
   - [x] 手順2: 各変換パターン（just now / minutes / hours / days / months）が正しく動作することを確認

## テスト
- [x] 単体テストを追加・更新しました
- [ ] 統合テストを追加・更新しました
- [x] 手動テストを実施しました

### テスト実行結果
```bash
$ zig build test --summary all
Build Summary: 7/7 steps succeeded; 13/13 tests passed
```

## 品質チェック
- [ ] `task lint` (Clippy) でコード品質チェックを通過
- [ ] `task fmt` でコード整形を実行
- [x] 不要なコメントやデバッグコードを削除

## マイグレーション（DBスキーマ変更がある場合）
- [ ] 該当なし

## スクリーンショット（UI変更がある場合）
- 該当なし

## 破壊的変更
- 破壊的変更なし