### PR TITLE
feat: CLIコマンドパーサーとテーブル/JSON出力を実装 (#7)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,6 +4,40 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    // ─── モジュール定義 ───────────────────────────────────────
+    const docker_types_mod = b.createModule(.{
+        .root_source_file = b.path("src/docker/types.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const docker_client_mod = b.createModule(.{
+        .root_source_file = b.path("src/docker/client.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const docker_api_mod = b.createModule(.{
+        .root_source_file = b.path("src/docker/api.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    docker_api_mod.addImport("client.zig", docker_client_mod);
+    docker_api_mod.addImport("types.zig", docker_types_mod);
+
+    const size_util_mod = b.createModule(.{
+        .root_source_file = b.path("src/utils/size.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const time_util_mod = b.createModule(.{
+        .root_source_file = b.path("src/utils/time.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // ─── 実行ファイル ─────────────────────────────────────────
     const exe_mod = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
         .target = target,
@@ -26,9 +60,10 @@ pub fn build(b: *std.Build) void {
     const run_step = b.step("run", "Run the application");
     run_step.dependOn(&run_cmd.step);
 
-    // Tests are rooted at src/main.zig which @import's other source files.
-    // When adding tests in separate files, import them from main.zig or add
-    // dedicated addTest targets here to ensure they are picked up by `zig build test`.
+    // ─── テストステップ ───────────────────────────────────────
+    const test_step = b.step("test", "Run unit tests");
+
+    // main.zig tests
     const test_mod = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
         .target = target,
@@ -40,17 +75,9 @@ pub fn build(b: *std.Build) void {
     });
 
     const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
-
-    const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_exe_unit_tests.step);
 
     // Size utility tests
-    const size_util_mod = b.createModule(.{
-        .root_source_file = b.path("src/utils/size.zig"),
-        .target = target,
-        .optimize = optimize,
-    });
-
     const size_test_mod = b.createModule(.{
         .root_source_file = b.path("tests/size_test.zig"),
         .target = target,
@@ -66,12 +93,6 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_size_tests.step);
 
     // Time utility tests
-    const time_util_mod = b.createModule(.{
-        .root_source_file = b.path("src/utils/time.zig"),
-        .target = target,
-        .optimize = optimize,
-    });
-
     const time_test_mod = b.createModule(.{
         .root_source_file = b.path("tests/time_test.zig"),
         .target = target,
@@ -87,12 +108,6 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_time_tests.step);
 
     // Docker types tests
-    const docker_types_mod = b.createModule(.{
-        .root_source_file = b.path("src/docker/types.zig"),
-        .target = target,
-        .optimize = optimize,
-    });
-
     const docker_types_test_mod = b.createModule(.{
         .root_source_file = b.path("tests/docker_types_test.zig"),
         .target = target,
@@ -108,12 +123,6 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_docker_types_tests.step);
 
     // Docker client tests
-    const docker_client_mod = b.createModule(.{
-        .root_source_file = b.path("src/docker/client.zig"),
-        .target = target,
-        .optimize = optimize,
-    });
-
     const docker_client_test_mod = b.createModule(.{
         .root_source_file = b.path("tests/client_test.zig"),
         .target = target,
@@ -129,14 +138,6 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_docker_client_tests.step);
 
     // Docker API tests
-    const docker_api_mod = b.createModule(.{
-        .root_source_file = b.path("src/docker/api.zig"),
-        .target = target,
-        .optimize = optimize,
-    });
-    docker_api_mod.addImport("client.zig", docker_client_mod);
-    docker_api_mod.addImport("types.zig", docker_types_mod);
-
     const docker_api_test_mod = b.createModule(.{
         .root_source_file = b.path("tests/api_test.zig"),
         .target = target,
@@ -150,4 +151,73 @@ pub fn build(b: *std.Build) void {
 
     const run_docker_api_tests = b.addRunArtifact(docker_api_tests);
     test_step.dependOn(&run_docker_api_tests.step);
+
+    // CLI commands tests
+    const cli_commands_mod = b.createModule(.{
+        .root_source_file = b.path("src/cli/commands.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const cli_commands_test_mod = b.createModule(.{
+        .root_source_file = b.path("tests/commands_test.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    cli_commands_test_mod.addImport("../src/cli/commands.zig", cli_commands_mod);
+
+    const cli_commands_tests = b.addTest(.{
+        .root_module = cli_commands_test_mod,
+    });
+
+    const run_cli_commands_tests = b.addRunArtifact(cli_commands_tests);
+    test_step.dependOn(&run_cli_commands_tests.step);
+
+    // CLI table tests
+    const cli_table_mod = b.createModule(.{
+        .root_source_file = b.path("src/cli/table.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    cli_table_mod.addImport("../docker/types.zig", docker_types_mod);
+    cli_table_mod.addImport("../utils/size.zig", size_util_mod);
+
+    const cli_table_test_mod = b.createModule(.{
+        .root_source_file = b.path("tests/table_test.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    cli_table_test_mod.addImport("../src/cli/table.zig", cli_table_mod);
+    cli_table_test_mod.addImport("../src/docker/types.zig", docker_types_mod);
+
+    const cli_table_tests = b.addTest(.{
+        .root_module = cli_table_test_mod,
+    });
+
+    const run_cli_table_tests = b.addRunArtifact(cli_table_tests);
+    test_step.dependOn(&run_cli_table_tests.step);
+
+    // CLI json_output tests
+    const cli_json_mod = b.createModule(.{
+        .root_source_file = b.path("src/cli/json_output.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    cli_json_mod.addImport("../docker/types.zig", docker_types_mod);
+
+    const cli_json_test_mod = b.createModule(.{
+        .root_source_file = b.path("tests/json_output_test.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    cli_json_test_mod.addImport("../src/cli/json_output.zig", cli_json_mod);
+    cli_json_test_mod.addImport("../src/docker/types.zig", docker_types_mod);
+
+    const cli_json_tests = b.addTest(.{
+        .root_module = cli_json_test_mod,
+    });
+
+    const run_cli_json_tests = b.addRunArtifact(cli_json_tests);
+    test_step.dependOn(&run_cli_json_tests.step);
+
 }

--- a/src/cli/commands.zig
+++ b/src/cli/commands.zig
@@ -1,0 +1,127 @@
+const std = @import("std");
+
+/// CLI で指定できるサブコマンド。
+pub const Command = enum {
+    containers,
+    images,
+    volumes,
+    help,
+};
+
+/// `dkill containers` のフィルタオプション。
+pub const ContainerFilter = struct {
+    /// --exited: 停止コンテナのみ表示
+    exited: bool = false,
+    /// --json: JSON 形式で出力
+    json: bool = false,
+};
+
+/// `dkill images` のフィルタオプション。
+pub const ImageFilter = struct {
+    /// --dangling: タグのないダングリングイメージのみ表示
+    dangling: bool = false,
+    /// --json: JSON 形式で出力
+    json: bool = false,
+};
+
+/// `dkill volumes` のフィルタオプション。
+pub const VolumeFilter = struct {
+    /// --orphaned: どのコンテナにも使われていないボリュームのみ表示
+    orphaned: bool = false,
+    /// --json: JSON 形式で出力
+    json: bool = false,
+};
+
+/// パース結果。コマンドとそれぞれのフィルタを保持する。
+pub const ParseResult = union(Command) {
+    containers: ContainerFilter,
+    images: ImageFilter,
+    volumes: VolumeFilter,
+    help: void,
+};
+
+/// ParseError はコマンドライン引数のパースに失敗したことを表す。
+pub const ParseError = error{
+    UnknownCommand,
+    UnknownFlag,
+};
+
+/// コマンドライン引数をパースして ParseResult を返す。
+/// args[0] はプログラム名を想定しているため読み飛ばす。
+pub fn parse(args: []const []const u8) ParseError!ParseResult {
+    // args[0] = argv[0] (プログラム名) をスキップ
+    const rest = if (args.len > 0) args[1..] else args;
+
+    if (rest.len == 0) return ParseResult{ .help = {} };
+
+    const cmd_str = rest[0];
+    const flags = if (rest.len > 1) rest[1..] else rest[0..0];
+
+    if (std.mem.eql(u8, cmd_str, "containers")) {
+        var filter = ContainerFilter{};
+        for (flags) |flag| {
+            if (std.mem.eql(u8, flag, "--exited")) {
+                filter.exited = true;
+            } else if (std.mem.eql(u8, flag, "--json")) {
+                filter.json = true;
+            } else {
+                return ParseError.UnknownFlag;
+            }
+        }
+        return ParseResult{ .containers = filter };
+    } else if (std.mem.eql(u8, cmd_str, "images")) {
+        var filter = ImageFilter{};
+        for (flags) |flag| {
+            if (std.mem.eql(u8, flag, "--dangling")) {
+                filter.dangling = true;
+            } else if (std.mem.eql(u8, flag, "--json")) {
+                filter.json = true;
+            } else {
+                return ParseError.UnknownFlag;
+            }
+        }
+        return ParseResult{ .images = filter };
+    } else if (std.mem.eql(u8, cmd_str, "volumes")) {
+        var filter = VolumeFilter{};
+        for (flags) |flag| {
+            if (std.mem.eql(u8, flag, "--orphaned")) {
+                filter.orphaned = true;
+            } else if (std.mem.eql(u8, flag, "--json")) {
+                filter.json = true;
+            } else {
+                return ParseError.UnknownFlag;
+            }
+        }
+        return ParseResult{ .volumes = filter };
+    } else if (std.mem.eql(u8, cmd_str, "help") or std.mem.eql(u8, cmd_str, "--help") or std.mem.eql(u8, cmd_str, "-h")) {
+        return ParseResult{ .help = {} };
+    } else {
+        return ParseError.UnknownCommand;
+    }
+}
+
+/// 使い方を標準出力に表示する。
+pub fn printUsage(writer: anytype) !void {
+    try writer.writeAll(
+        \\Usage: dkill <command> [flags]
+        \\
+        \\Commands:
+        \\  containers  List containers
+        \\  images      List images
+        \\  volumes     List volumes
+        \\  help        Show this help message
+        \\
+        \\Flags for containers:
+        \\  --exited    Show only exited containers
+        \\  --json      Output as JSON
+        \\
+        \\Flags for images:
+        \\  --dangling  Show only dangling images
+        \\  --json      Output as JSON
+        \\
+        \\Flags for volumes:
+        \\  --orphaned  Show only orphaned volumes
+        \\  --json      Output as JSON
+        \\
+    );
+}

--- a/src/cli/json_output.zig
+++ b/src/cli/json_output.zig
@@ -1,0 +1,74 @@
+const std = @import("std");
+const types = @import("../docker/types.zig");
+
+/// コンテナ一覧を JSON 配列として writer に出力する。
+pub fn printContainersJson(writer: anytype, containers: []const types.Container) !void {
+    try writer.writeAll("[\n");
+    for (containers, 0..) |c, i| {
+        try writer.writeAll("  {\n");
+        try writer.print("    \"id\": \"{s}\",\n", .{c.Id});
+        try writer.writeAll("    \"names\": [");
+        for (c.Names, 0..) |name, j| {
+            if (j > 0) try writer.writeAll(", ");
+            try writer.print("\"{s}\"", .{name});
+        }
+        try writer.writeAll("],\n");
+        try writer.print("    \"image\": \"{s}\",\n", .{c.Image});
+        try writer.print("    \"state\": \"{s}\",\n", .{c.State});
+        try writer.print("    \"status\": \"{s}\"\n", .{c.Status});
+        if (i + 1 < containers.len) {
+            try writer.writeAll("  },\n");
+        } else {
+            try writer.writeAll("  }\n");
+        }
+    }
+    try writer.writeAll("]\n");
+}
+
+/// イメージ一覧を JSON 配列として writer に出力する。
+pub fn printImagesJson(writer: anytype, images: []const types.Image) !void {
+    try writer.writeAll("[\n");
+    for (images, 0..) |img, i| {
+        try writer.writeAll("  {\n");
+        try writer.print("    \"id\": \"{s}\",\n", .{img.Id});
+        try writer.writeAll("    \"repoTags\": [");
+        for (img.RepoTags, 0..) |tag, j| {
+            if (j > 0) try writer.writeAll(", ");
+            try writer.print("\"{s}\"", .{tag});
+        }
+        try writer.writeAll("],\n");
+        try writer.print("    \"size\": {d}\n", .{img.Size});
+        if (i + 1 < images.len) {
+            try writer.writeAll("  },\n");
+        } else {
+            try writer.writeAll("  }\n");
+        }
+    }
+    try writer.writeAll("]\n");
+}
+
+/// ボリューム一覧を JSON 配列として writer に出力する。
+pub fn printVolumesJson(writer: anytype, volumes: []const types.Volume) !void {
+    try writer.writeAll("[\n");
+    for (volumes, 0..) |v, i| {
+        try writer.writeAll("  {\n");
+        try writer.print("    \"name\": \"{s}\",\n", .{v.Name});
+        try writer.print("    \"driver\": \"{s}\",\n", .{v.Driver});
+        try writer.print("    \"mountpoint\": \"{s}\"", .{v.Mountpoint});
+        if (v.UsageData) |usage| {
+            try writer.writeAll(",\n");
+            try writer.writeAll("    \"usageData\": {\n");
+            try writer.print("      \"refCount\": {d},\n", .{usage.RefCount});
+            try writer.print("      \"size\": {d}\n", .{usage.Size});
+            try writer.writeAll("    }\n");
+        } else {
+            try writer.writeAll("\n");
+        }
+        if (i + 1 < volumes.len) {
+            try writer.writeAll("  },\n");
+        } else {
+            try writer.writeAll("  }\n");
+        }
+    }
+    try writer.writeAll("]\n");
+}

--- a/src/cli/table.zig
+++ b/src/cli/table.zig
@@ -1,0 +1,63 @@
+const std = @import("std");
+const types = @import("../docker/types.zig");
+const size_util = @import("../utils/size.zig");
+
+/// コンテナ一覧をテーブル形式で writer に出力する。
+pub fn printContainers(writer: anytype, containers: []const types.Container) !void {
+    try writer.writeAll("CONTAINER ID    IMAGE                           STATUS\n");
+    try writer.writeAll("------------    -----                           ------\n");
+    for (containers) |c| {
+        const name = if (c.Names.len > 0) c.Names[0] else "(no name)";
+        try writer.print("{s:<16}{s:<32}{s}\n", .{
+            c.shortId(),
+            c.Image,
+            name,
+        });
+        _ = c.Status;
+    }
+}
+
+/// コンテナ一覧をテーブル形式で writer に出力する（詳細版: ID / Names / Image / State / Status）。
+pub fn printContainersDetailed(writer: anytype, containers: []const types.Container) !void {
+    try writer.writeAll("CONTAINER ID    NAMES                           IMAGE                           STATE       STATUS\n");
+    try writer.writeAll("------------    -----                           -----                           -----       ------\n");
+    for (containers) |c| {
+        const name = if (c.Names.len > 0) c.Names[0] else "(no name)";
+        try writer.print("{s:<16}{s:<32}{s:<32}{s:<12}{s}\n", .{
+            c.shortId(),
+            name,
+            c.Image,
+            c.State,
+            c.Status,
+        });
+    }
+}
+
+/// イメージ一覧をテーブル形式で writer に出力する。
+pub fn printImages(writer: anytype, images: []const types.Image) !void {
+    try writer.writeAll("IMAGE ID        REPOSITORY:TAG                  SIZE\n");
+    try writer.writeAll("--------        --------------                  ----\n");
+    for (images) |img| {
+        var size_buf: [16]u8 = undefined;
+        const size_str = size_util.humanReadable(img.Size, &size_buf);
+        const short_id = if (img.Id.len >= 12) img.Id[0..12] else img.Id;
+        try writer.print("{s:<16}{s:<32}{s}\n", .{
+            short_id,
+            img.displayTag(),
+            size_str,
+        });
+    }
+}
+
+/// ボリューム一覧をテーブル形式で writer に出力する。
+pub fn printVolumes(writer: anytype, volumes: []const types.Volume) !void {
+    try writer.writeAll("VOLUME NAME                     DRIVER      MOUNTPOINT\n");
+    try writer.writeAll("-----------                     ------      ----------\n");
+    for (volumes) |v| {
+        try writer.print("{s:<32}{s:<12}{s}\n", .{
+            v.Name,
+            v.Driver,
+            v.Mountpoint,
+        });
+    }
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,18 +1,143 @@
 const std = @import("std");
+const commands = @import("cli/commands.zig");
+const table = @import("cli/table.zig");
+const json_output = @import("cli/json_output.zig");
+const api = @import("docker/api.zig");
 
 pub const version = "0.1.0";
+
+const DOCKER_SOCKET = "/var/run/docker.sock";
 
 fn versionString() []const u8 {
     return "dkill v" ++ version;
 }
 
 pub fn main() !void {
-    var stdout_buffer: [1024]u8 = undefined;
-    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
-    const stdout = &stdout_writer.interface;
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
 
-    try stdout.print("{s}\n", .{versionString()});
-    try stdout.flush();
+    const args = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, args);
+
+    var stdout_buf: [65536]u8 = undefined;
+    var stdout_file_writer = std.fs.File.stdout().writer(&stdout_buf);
+    const stdout = &stdout_file_writer.interface;
+
+    var stderr_buf: [4096]u8 = undefined;
+    var stderr_file_writer = std.fs.File.stderr().writer(&stderr_buf);
+    const stderr = &stderr_file_writer.interface;
+
+    const result = commands.parse(args) catch |err| {
+        switch (err) {
+            error.UnknownCommand => try stderr.print("error: unknown command\n\n", .{}),
+            error.UnknownFlag => try stderr.print("error: unknown flag\n\n", .{}),
+        }
+        try commands.printUsage(stderr);
+        try stderr.flush();
+        std.process.exit(1);
+    };
+
+    switch (result) {
+        .help => {
+            try stdout.print("{s}\n\n", .{versionString()});
+            try commands.printUsage(stdout);
+            try stdout.flush();
+        },
+        .containers => |filter| {
+            var docker = api.DockerApi.init(allocator, DOCKER_SOCKET);
+            const containers = docker.listContainers() catch |err| {
+                try stderr.print("error: failed to list containers: {s}\n", .{@errorName(err)});
+                try stderr.flush();
+                std.process.exit(1);
+            };
+            defer {
+                for (containers) |c| {
+                    allocator.free(c.Id);
+                    allocator.free(c.Image);
+                    allocator.free(c.State);
+                    allocator.free(c.Status);
+                    for (c.Names) |name| allocator.free(name);
+                    allocator.free(c.Names);
+                }
+                allocator.free(containers);
+            }
+
+            var filtered = std.ArrayList(@TypeOf(containers[0])){};
+            defer filtered.deinit(allocator);
+            for (containers) |c| {
+                if (filter.exited and !c.isExited()) continue;
+                try filtered.append(allocator, c);
+            }
+
+            if (filter.json) {
+                try json_output.printContainersJson(stdout, filtered.items);
+            } else {
+                try table.printContainersDetailed(stdout, filtered.items);
+            }
+            try stdout.flush();
+        },
+        .images => |filter| {
+            var docker = api.DockerApi.init(allocator, DOCKER_SOCKET);
+            const images = docker.listImages() catch |err| {
+                try stderr.print("error: failed to list images: {s}\n", .{@errorName(err)});
+                try stderr.flush();
+                std.process.exit(1);
+            };
+            defer {
+                for (images) |img| {
+                    allocator.free(img.Id);
+                    for (img.RepoTags) |tag| allocator.free(tag);
+                    allocator.free(img.RepoTags);
+                }
+                allocator.free(images);
+            }
+
+            var filtered = std.ArrayList(@TypeOf(images[0])){};
+            defer filtered.deinit(allocator);
+            for (images) |img| {
+                if (filter.dangling and !img.isDangling()) continue;
+                try filtered.append(allocator, img);
+            }
+
+            if (filter.json) {
+                try json_output.printImagesJson(stdout, filtered.items);
+            } else {
+                try table.printImages(stdout, filtered.items);
+            }
+            try stdout.flush();
+        },
+        .volumes => |filter| {
+            var docker = api.DockerApi.init(allocator, DOCKER_SOCKET);
+            const volumes = docker.listVolumes() catch |err| {
+                try stderr.print("error: failed to list volumes: {s}\n", .{@errorName(err)});
+                try stderr.flush();
+                std.process.exit(1);
+            };
+            defer {
+                for (volumes) |v| {
+                    allocator.free(v.Name);
+                    allocator.free(v.Driver);
+                    allocator.free(v.Mountpoint);
+                }
+                allocator.free(volumes);
+            }
+
+            var filtered = std.ArrayList(@TypeOf(volumes[0])){};
+            defer filtered.deinit(allocator);
+            for (volumes) |v| {
+                if (filter.orphaned and !v.isOrphaned()) continue;
+                try filtered.append(allocator, v);
+            }
+
+            if (filter.json) {
+                try json_output.printVolumesJson(stdout, filtered.items);
+            } else {
+                try table.printVolumes(stdout, filtered.items);
+            }
+            try stdout.flush();
+        },
+    }
 }
 
 test "version string" {

--- a/tests/commands_test.zig
+++ b/tests/commands_test.zig
@@ -1,0 +1,136 @@
+const std = @import("std");
+const commands = @import("../src/cli/commands.zig");
+
+// ─── parse: 引数なし ────────────────────────────────────────
+test "parse: no args returns help" {
+    const result = try commands.parse(&.{"dkill"});
+    try std.testing.expect(result == .help);
+}
+
+// ─── parse: containers ──────────────────────────────────────
+test "parse: containers no flags" {
+    const result = try commands.parse(&.{ "dkill", "containers" });
+    try std.testing.expect(result == .containers);
+    try std.testing.expect(!result.containers.exited);
+    try std.testing.expect(!result.containers.json);
+}
+
+test "parse: containers --exited" {
+    const result = try commands.parse(&.{ "dkill", "containers", "--exited" });
+    try std.testing.expect(result == .containers);
+    try std.testing.expect(result.containers.exited);
+    try std.testing.expect(!result.containers.json);
+}
+
+test "parse: containers --json" {
+    const result = try commands.parse(&.{ "dkill", "containers", "--json" });
+    try std.testing.expect(result == .containers);
+    try std.testing.expect(!result.containers.exited);
+    try std.testing.expect(result.containers.json);
+}
+
+test "parse: containers --exited --json" {
+    const result = try commands.parse(&.{ "dkill", "containers", "--exited", "--json" });
+    try std.testing.expect(result == .containers);
+    try std.testing.expect(result.containers.exited);
+    try std.testing.expect(result.containers.json);
+}
+
+// ─── parse: images ──────────────────────────────────────────
+test "parse: images no flags" {
+    const result = try commands.parse(&.{ "dkill", "images" });
+    try std.testing.expect(result == .images);
+    try std.testing.expect(!result.images.dangling);
+    try std.testing.expect(!result.images.json);
+}
+
+test "parse: images --dangling" {
+    const result = try commands.parse(&.{ "dkill", "images", "--dangling" });
+    try std.testing.expect(result == .images);
+    try std.testing.expect(result.images.dangling);
+}
+
+test "parse: images --dangling --json" {
+    const result = try commands.parse(&.{ "dkill", "images", "--dangling", "--json" });
+    try std.testing.expect(result == .images);
+    try std.testing.expect(result.images.dangling);
+    try std.testing.expect(result.images.json);
+}
+
+// ─── parse: volumes ─────────────────────────────────────────
+test "parse: volumes no flags" {
+    const result = try commands.parse(&.{ "dkill", "volumes" });
+    try std.testing.expect(result == .volumes);
+    try std.testing.expect(!result.volumes.orphaned);
+    try std.testing.expect(!result.volumes.json);
+}
+
+test "parse: volumes --orphaned" {
+    const result = try commands.parse(&.{ "dkill", "volumes", "--orphaned" });
+    try std.testing.expect(result == .volumes);
+    try std.testing.expect(result.volumes.orphaned);
+}
+
+test "parse: volumes --orphaned --json" {
+    const result = try commands.parse(&.{ "dkill", "volumes", "--orphaned", "--json" });
+    try std.testing.expect(result == .volumes);
+    try std.testing.expect(result.volumes.orphaned);
+    try std.testing.expect(result.volumes.json);
+}
+
+// ─── parse: help ────────────────────────────────────────────
+test "parse: help command" {
+    const result = try commands.parse(&.{ "dkill", "help" });
+    try std.testing.expect(result == .help);
+}
+
+test "parse: --help flag" {
+    const result = try commands.parse(&.{ "dkill", "--help" });
+    try std.testing.expect(result == .help);
+}
+
+test "parse: -h flag" {
+    const result = try commands.parse(&.{ "dkill", "-h" });
+    try std.testing.expect(result == .help);
+}
+
+// ─── parse: エラーケース ─────────────────────────────────────
+test "parse: unknown command returns error" {
+    try std.testing.expectError(
+        error.UnknownCommand,
+        commands.parse(&.{ "dkill", "unknown" }),
+    );
+}
+
+test "parse: unknown flag for containers returns error" {
+    try std.testing.expectError(
+        error.UnknownFlag,
+        commands.parse(&.{ "dkill", "containers", "--bad-flag" }),
+    );
+}
+
+test "parse: unknown flag for images returns error" {
+    try std.testing.expectError(
+        error.UnknownFlag,
+        commands.parse(&.{ "dkill", "images", "--bad-flag" }),
+    );
+}
+
+test "parse: unknown flag for volumes returns error" {
+    try std.testing.expectError(
+        error.UnknownFlag,
+        commands.parse(&.{ "dkill", "volumes", "--bad-flag" }),
+    );
+}
+
+// ─── printUsage ─────────────────────────────────────────────
+test "printUsage writes usage text" {
+    var buf: [2048]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    try commands.printUsage(fbs.writer());
+    const written = fbs.getWritten();
+    try std.testing.expect(std.mem.indexOf(u8, written, "Usage:") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "containers") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "images") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "volumes") != null);
+}

--- a/tests/json_output_test.zig
+++ b/tests/json_output_test.zig
@@ -1,0 +1,100 @@
+const std = @import("std");
+const json_output = @import("../src/cli/json_output.zig");
+const types = @import("../src/docker/types.zig");
+
+test "printContainersJson outputs valid JSON structure" {
+    const names1 = [_][]const u8{"/mycontainer"};
+    const containers = [_]types.Container{
+        .{
+            .Id = "abc123",
+            .Names = &names1,
+            .Image = "nginx:latest",
+            .State = "running",
+            .Status = "Up 2 hours",
+        },
+    };
+
+    var buf: [2048]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    try json_output.printContainersJson(fbs.writer(), &containers);
+    const written = fbs.getWritten();
+
+    try std.testing.expect(std.mem.indexOf(u8, written, "\"id\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "abc123") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "\"image\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "nginx:latest") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "\"state\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "running") != null);
+    // JSON 配列として開始・終了
+    try std.testing.expect(written[0] == '[');
+    try std.testing.expect(written[written.len - 2] == ']' or written[written.len - 1] == ']');
+}
+
+test "printContainersJson empty list outputs empty array" {
+    var buf: [64]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    try json_output.printContainersJson(fbs.writer(), &.{});
+    const written = fbs.getWritten();
+    try std.testing.expect(std.mem.indexOf(u8, written, "[") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "]") != null);
+}
+
+test "printImagesJson outputs valid JSON structure" {
+    const tags = [_][]const u8{"nginx:latest"};
+    const images = [_]types.Image{
+        .{
+            .Id = "sha256:abc",
+            .RepoTags = &tags,
+            .Size = 1024,
+        },
+    };
+
+    var buf: [1024]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    try json_output.printImagesJson(fbs.writer(), &images);
+    const written = fbs.getWritten();
+
+    try std.testing.expect(std.mem.indexOf(u8, written, "\"id\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "\"repoTags\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "\"size\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "1024") != null);
+}
+
+test "printVolumesJson outputs valid JSON structure" {
+    const volumes = [_]types.Volume{
+        .{
+            .Name = "myvolume",
+            .Driver = "local",
+            .Mountpoint = "/data",
+            .UsageData = .{ .RefCount = 2, .Size = 512 },
+        },
+    };
+
+    var buf: [1024]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    try json_output.printVolumesJson(fbs.writer(), &volumes);
+    const written = fbs.getWritten();
+
+    try std.testing.expect(std.mem.indexOf(u8, written, "\"name\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "myvolume") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "\"usageData\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "\"refCount\"") != null);
+}
+
+test "printVolumesJson null UsageData omits usageData field" {
+    const volumes = [_]types.Volume{
+        .{
+            .Name = "orphan",
+            .Driver = "local",
+            .Mountpoint = "/data",
+            .UsageData = null,
+        },
+    };
+
+    var buf: [512]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    try json_output.printVolumesJson(fbs.writer(), &volumes);
+    const written = fbs.getWritten();
+
+    try std.testing.expect(std.mem.indexOf(u8, written, "usageData") == null);
+}

--- a/tests/table_test.zig
+++ b/tests/table_test.zig
@@ -1,0 +1,74 @@
+const std = @import("std");
+const table = @import("../src/cli/table.zig");
+const types = @import("../src/docker/types.zig");
+
+test "printContainersDetailed outputs header and rows" {
+    const names1 = [_][]const u8{"/mycontainer"};
+    const containers = [_]types.Container{
+        .{
+            .Id = "abc123def456789",
+            .Names = &names1,
+            .Image = "nginx:latest",
+            .State = "running",
+            .Status = "Up 2 hours",
+        },
+    };
+
+    var buf: [1024]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    try table.printContainersDetailed(fbs.writer(), &containers);
+    const written = fbs.getWritten();
+
+    try std.testing.expect(std.mem.indexOf(u8, written, "CONTAINER ID") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "abc123def456") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "nginx:latest") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "running") != null);
+}
+
+test "printImages outputs header and rows" {
+    const tags = [_][]const u8{"nginx:latest"};
+    const images = [_]types.Image{
+        .{
+            .Id = "sha256:abc123def456789",
+            .RepoTags = &tags,
+            .Size = 1024 * 1024 * 50,
+        },
+    };
+
+    var buf: [1024]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    try table.printImages(fbs.writer(), &images);
+    const written = fbs.getWritten();
+
+    try std.testing.expect(std.mem.indexOf(u8, written, "IMAGE ID") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "nginx:latest") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "MB") != null);
+}
+
+test "printVolumes outputs header and rows" {
+    const volumes = [_]types.Volume{
+        .{
+            .Name = "myvolume",
+            .Driver = "local",
+            .Mountpoint = "/var/lib/docker/volumes/myvolume/_data",
+            .UsageData = null,
+        },
+    };
+
+    var buf: [1024]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    try table.printVolumes(fbs.writer(), &volumes);
+    const written = fbs.getWritten();
+
+    try std.testing.expect(std.mem.indexOf(u8, written, "VOLUME NAME") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "myvolume") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "local") != null);
+}
+
+test "printContainersDetailed empty list outputs only header" {
+    var buf: [512]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    try table.printContainersDetailed(fbs.writer(), &.{});
+    const written = fbs.getWritten();
+    try std.testing.expect(std.mem.indexOf(u8, written, "CONTAINER ID") != null);
+}


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## レビューに関して
レビューする際には、以下のprefix(接頭辞)を付けましょう。
[must] → かならず変更してね
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)
[nits] → ささいな指摘(nitpick)
[ask] → 質問
[fyi] → 参考情報

## Issues No
close #7

## 概要
`dkill containers --exited` のような非インタラクティブな CLI コマンドを動作させるため、引数パーサーとテーブル/JSON 出力モジュールを実装し、`main.zig` に接続しました。

## 変更内容
### 追加機能
- [x] `src/cli/commands.zig` — CLIパーサー（`Command` enum, `ContainerFilter`/`ImageFilter`/`VolumeFilter` 構造体, `parse()`, `printUsage()`）
- [x] `src/cli/table.zig` — テーブル形式出力（`printContainersDetailed` / `printImages` / `printVolumes`）
- [x] `src/cli/json_output.zig` — JSON形式出力（`printContainersJson` / `printImagesJson` / `printVolumesJson`）
- [x] `src/main.zig` — サブコマンドディスパッチ、Docker API呼び出し、フィルタ適用

### その他の変更
- [x] テスト追加（`tests/commands_test.zig`, `tests/table_test.zig`, `tests/json_output_test.zig`）
- [x] `build.zig` に新テストモジュールを追加

## 動作確認手順

2. 確認手順
   - [x] `zig build` が成功する
   - [ ] `dkill containers --exited` で停止コンテナ一覧が表示される（Docker 起動時）
   - [ ] `dkill images --dangling --json` で JSON 出力される

## テスト
- [x] 単体テストを追加・更新しました
- [ ] 統合テストを追加・更新しました
- [ ] 手動テストを実施しました

### テスト実行結果
```bash
$ zig build test
# 全テストパス（exit code 0）
```

テスト内容:
- `commands_test.zig`: 16テストケース（正常系・エラー系）
- `table_test.zig`: 4テストケース
- `json_output_test.zig`: 5テストケース

## 品質チェック
- [x] `zig build` でビルド成功
- [x] `zig build test` で全テストパス
- [x] 不要なコメントやデバッグコードを削除

## 破壊的変更
なし（`main.zig` のエントリポイントを置き換えましたが、以前は `versionString()` を出力するのみでした）