### PR TITLE
fix: HTTP chunked encoding対応・TUI高速化・カラー表示改善

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Zig 0.15.x
         uses: mlugg/setup-zig@v1
         with:
-          version: 0.15.0
+          version: 0.15.2
 
       - name: Build
         run: zig build
@@ -29,7 +29,7 @@ jobs:
 
       - name: Check binary size (< 1MB)
         run: |
-          SIZE=$(stat -c%s zig-out/bin/dkill)
+          SIZE=$(stat -c%s zig-out/bin/dk)
           echo "Binary size: ${SIZE} bytes"
           if [ "${SIZE}" -ge 1048576 ]; then
             echo "ERROR: Binary size ${SIZE} bytes exceeds 1MB limit"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Zig 0.15.0
+      - name: Install Zig 0.15.2
         run: |
-          wget -q https://ziglang.org/download/0.15.0/zig-linux-x86_64-0.15.0.tar.xz
-          tar -xf zig-linux-x86_64-0.15.0.tar.xz
-          echo "$PWD/zig-linux-x86_64-0.15.0" >> $GITHUB_PATH
+          wget -q https://ziglang.org/download/0.15.2/zig-linux-x86_64-0.15.2.tar.xz
+          tar -xf zig-linux-x86_64-0.15.2.tar.xz
+          echo "$PWD/zig-linux-x86_64-0.15.2" >> $GITHUB_PATH
 
       - name: Build
         run: zig build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Zig
-        uses: mlugg/setup-zig@v1
-        with:
-          version: master
+      - name: Install Zig 0.15.0
+        run: |
+          wget -q https://ziglang.org/download/0.15.0/zig-linux-x86_64-0.15.0.tar.xz
+          tar -xf zig-linux-x86_64-0.15.0.tar.xz
+          echo "$PWD/zig-linux-x86_64-0.15.0" >> $GITHUB_PATH
 
       - name: Build
         run: zig build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
 
       - name: Install Zig 0.15.2
         run: |
-          wget -q https://ziglang.org/download/0.15.2/zig-linux-x86_64-0.15.2.tar.xz
-          tar -xf zig-linux-x86_64-0.15.2.tar.xz
-          echo "$PWD/zig-linux-x86_64-0.15.2" >> $GITHUB_PATH
+          wget -q https://ziglang.org/download/0.15.2/zig-x86_64-linux-0.15.2.tar.xz
+          tar -xf zig-x86_64-linux-0.15.2.tar.xz
+          echo "$PWD/zig-x86_64-linux-0.15.2" >> $GITHUB_PATH
 
       - name: Build
         run: zig build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Zig 0.15.x
+      - name: Install Zig
         uses: mlugg/setup-zig@v1
         with:
-          version: 0.15.2
+          version: master
 
       - name: Build
         run: zig build

--- a/build.zig
+++ b/build.zig
@@ -104,7 +104,7 @@ pub fn build(b: *std.Build) void {
     cli_json_mod.addImport("../docker/types.zig", docker_types_mod);
 
     const exe = b.addExecutable(.{
-        .name = "dkill",
+        .name = "dk",
         .root_module = b.createModule(.{
             .root_source_file = b.path("src/main.zig"),
             .target = target,

--- a/src/docker/api.zig
+++ b/src/docker/api.zig
@@ -20,7 +20,7 @@ pub const DockerApi = struct {
     /// コンテナ一覧取得（all=true で停止コンテナも含む）。
     /// 返り値のスライスおよび各フィールドの文字列は呼び出し元が解放する必要がある。
     pub fn listContainers(self: *DockerApi) ![]types.Container {
-        const body = try self.c.get("/" ++ API_VERSION ++ "/containers/json?all=true&size=true");
+        const body = try self.c.get("/" ++ API_VERSION ++ "/containers/json?all=true");
         defer self.allocator.free(body);
         return parseContainers(self.allocator, body);
     }

--- a/src/docker/client.zig
+++ b/src/docker/client.zig
@@ -73,6 +73,21 @@ pub const DockerClient = struct {
     }
 };
 
+/// テスト用: 生の HTTP レスポンス文字列を解析してボディを返す。
+pub fn parseHttpResponse(allocator: std.mem.Allocator, raw: []const u8) ![]u8 {
+    const status_code = try parseStatusCode(raw);
+    if (status_code < 200 or status_code >= 300) return error.HttpError;
+
+    const header_end = std.mem.indexOf(u8, raw, "\r\n\r\n") orelse return error.InvalidResponse;
+    const headers = raw[0..header_end];
+    const body_raw = raw[header_end + 4 ..];
+
+    if (isChunked(headers)) {
+        return try decodeChunked(allocator, body_raw);
+    }
+    return try allocator.dupe(u8, body_raw);
+}
+
 /// HTTP レスポンスが完結しているか判定する。
 /// Content-Length があれば必要バイト数、chunked なら終端マーカーで判断する。
 fn isResponseComplete(data: []const u8) bool {

--- a/src/docker/client.zig
+++ b/src/docker/client.zig
@@ -12,24 +12,23 @@ pub const DockerClient = struct {
         };
     }
 
-    /// GET リクエストを送信し、レスポンスボディを返す。
-    /// raw バッファを再利用してボディ部分だけを返すため、余分なコピーを行わない。
+    /// GET リクエストを送信し、デコード済みレスポンスボディを返す。
     /// 返り値はアロケータで確保されたスライス。呼び出し元が解放する必要がある。
     pub fn get(self: *DockerClient, path: []const u8) ![]u8 {
         const raw = try self.sendRequest("GET", path);
-        errdefer self.allocator.free(raw);
+        defer self.allocator.free(raw);
 
         const status_code = try parseStatusCode(raw);
         if (status_code < 200 or status_code >= 300) return error.HttpError;
 
         const header_end = std.mem.indexOf(u8, raw, "\r\n\r\n") orelse return error.InvalidResponse;
-        const body_start = header_end + 4;
-        const body_len = raw.len - body_start;
+        const headers = raw[0..header_end];
+        const body_raw = raw[header_end + 4 ..];
 
-        if (body_len > 0) {
-            std.mem.copyForwards(u8, raw[0..body_len], raw[body_start..]);
+        if (isChunked(headers)) {
+            return try decodeChunked(self.allocator, body_raw);
         }
-        return self.allocator.realloc(raw, body_len);
+        return try self.allocator.dupe(u8, body_raw);
     }
 
     /// DELETE リクエストを送信し、ステータスコードを返す。
@@ -61,29 +60,91 @@ pub const DockerClient = struct {
 
         var response = std.ArrayListUnmanaged(u8){};
         defer response.deinit(self.allocator);
-        var buf: [4096]u8 = undefined;
+        var buf: [65536]u8 = undefined;
         while (true) {
             const n = try stream.read(&buf);
             if (n == 0) break;
             try response.appendSlice(self.allocator, buf[0..n]);
+            // EOF を待たず、レスポンスが完結したら即終了
+            if (isResponseComplete(response.items)) break;
         }
 
         return try response.toOwnedSlice(self.allocator);
     }
 };
 
-/// HTTP/1.1 レスポンスをパースしてボディを返す。
-/// ステータスコードが 2xx でない場合はエラーを返す。
-/// 返り値はアロケータで確保されたスライス。呼び出し元が解放する必要がある。
-pub fn parseHttpResponse(allocator: std.mem.Allocator, raw: []const u8) ![]const u8 {
-    const status_code = try parseStatusCode(raw);
-    if (status_code < 200 or status_code >= 300) {
-        return error.HttpError;
+/// HTTP レスポンスが完結しているか判定する。
+/// Content-Length があれば必要バイト数、chunked なら終端マーカーで判断する。
+fn isResponseComplete(data: []const u8) bool {
+    const header_end = std.mem.indexOf(u8, data, "\r\n\r\n") orelse return false;
+    const headers = data[0..header_end];
+    const body = data[header_end + 4 ..];
+
+    // Content-Length で判断
+    if (getContentLength(headers)) |content_length| {
+        return body.len >= content_length;
     }
 
-    const header_end = std.mem.indexOf(u8, raw, "\r\n\r\n") orelse return error.InvalidResponse;
-    const body = raw[header_end + 4 ..];
-    return try allocator.dupe(u8, body);
+    // Chunked エンコーディングの終端マーカー "\r\n0\r\n\r\n" で判断
+    if (isChunked(headers)) {
+        return std.mem.endsWith(u8, data, "\r\n0\r\n\r\n");
+    }
+
+    return false;
+}
+
+/// Content-Length ヘッダーの値を返す。
+fn getContentLength(headers: []const u8) ?usize {
+    var it = std.mem.splitScalar(u8, headers, '\n');
+    while (it.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, "\r ");
+        const prefix = "content-length:";
+        if (trimmed.len > prefix.len and
+            std.ascii.eqlIgnoreCase(trimmed[0..prefix.len], prefix))
+        {
+            const value = std.mem.trim(u8, trimmed[prefix.len..], " ");
+            return std.fmt.parseInt(usize, value, 10) catch null;
+        }
+    }
+    return null;
+}
+
+/// レスポンスヘッダーに Transfer-Encoding: chunked が含まれるか確認する。
+fn isChunked(headers: []const u8) bool {
+    var it = std.mem.splitScalar(u8, headers, '\n');
+    while (it.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, "\r ");
+        if (std.ascii.eqlIgnoreCase(trimmed, "transfer-encoding: chunked")) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/// Chunked Transfer Encoding をデコードして生のボディを返す。
+fn decodeChunked(allocator: std.mem.Allocator, data: []const u8) ![]u8 {
+    var result = std.ArrayListUnmanaged(u8){};
+    errdefer result.deinit(allocator);
+
+    var pos: usize = 0;
+    while (pos < data.len) {
+        // チャンクサイズ行を読む
+        const line_end = std.mem.indexOf(u8, data[pos..], "\r\n") orelse break;
+        const size_str = std.mem.trim(u8, data[pos .. pos + line_end], " \t");
+        // チャンク拡張（";"以降）を無視
+        const semi = std.mem.indexOfScalar(u8, size_str, ';');
+        const hex_str = if (semi) |s| size_str[0..s] else size_str;
+        const chunk_size = std.fmt.parseInt(usize, hex_str, 16) catch break;
+
+        pos += line_end + 2;
+        if (chunk_size == 0) break; // 最終チャンク
+
+        if (pos + chunk_size > data.len) return error.InvalidChunk;
+        try result.appendSlice(allocator, data[pos .. pos + chunk_size]);
+        pos += chunk_size + 2; // データ + 末尾 CRLF をスキップ
+    }
+
+    return try result.toOwnedSlice(allocator);
 }
 
 fn parseStatusCode(raw: []const u8) !u16 {

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -6,6 +6,40 @@ const list_mod = @import("list.zig");
 const render = @import("render.zig");
 const input = @import("input.zig");
 
+/// 並列ロード用の結果バッファ。
+const LoadResult = struct {
+    containers: []types.Container = &.{},
+    images: []types.Image = &.{},
+    volumes: []types.Volume = &.{},
+    container_err: ?anyerror = null,
+    image_err: ?anyerror = null,
+    volume_err: ?anyerror = null,
+};
+
+fn loadContainersWorker(allocator: std.mem.Allocator, socket_path: []const u8, result: *LoadResult) void {
+    var docker = api.DockerApi.init(allocator, socket_path);
+    result.containers = docker.listContainers() catch |err| blk: {
+        result.container_err = err;
+        break :blk &.{};
+    };
+}
+
+fn loadImagesWorker(allocator: std.mem.Allocator, socket_path: []const u8, result: *LoadResult) void {
+    var docker = api.DockerApi.init(allocator, socket_path);
+    result.images = docker.listImages() catch |err| blk: {
+        result.image_err = err;
+        break :blk &.{};
+    };
+}
+
+fn loadVolumesWorker(allocator: std.mem.Allocator, socket_path: []const u8, result: *LoadResult) void {
+    var docker = api.DockerApi.init(allocator, socket_path);
+    result.volumes = docker.listVolumes() catch |err| blk: {
+        result.volume_err = err;
+        break :blk &.{};
+    };
+}
+
 /// TUI のモード。
 pub const AppMode = enum {
     normal,
@@ -76,14 +110,31 @@ pub const App = struct {
         self.freeLists();
     }
 
-    /// Docker API からデータを取得してリストを構築する。
+    /// Docker API からデータを取得してリストを構築する（3エンドポイントを並列取得）。
     pub fn loadData(self: *App) !void {
         self.freeLists();
 
-        var docker = api.DockerApi.init(self.allocator, self.socket_path);
+        // スレッドセーフなアロケータでラップして並列取得
+        var ts_alloc = std.heap.ThreadSafeAllocator{ .child_allocator = self.allocator };
+        const ts = ts_alloc.allocator();
 
-        // コンテナ
-        self.containers = try docker.listContainers();
+        var lr = LoadResult{};
+        const t1 = try std.Thread.spawn(.{}, loadContainersWorker, .{ ts, self.socket_path, &lr });
+        const t2 = try std.Thread.spawn(.{}, loadImagesWorker, .{ ts, self.socket_path, &lr });
+        const t3 = try std.Thread.spawn(.{}, loadVolumesWorker, .{ ts, self.socket_path, &lr });
+        t1.join();
+        t2.join();
+        t3.join();
+
+        if (lr.container_err) |err| return err;
+        if (lr.image_err) |err| return err;
+        if (lr.volume_err) |err| return err;
+
+        self.containers = lr.containers;
+        self.images = lr.images;
+        self.volumes = lr.volumes;
+
+        // コンテナ UI アイテムを構築
         self.container_items = try self.allocator.alloc(list_mod.SelectableItem, self.containers.len);
         self.container_labels = try self.allocator.alloc([]u8, self.containers.len);
         for (self.containers, 0..) |c, i| {
@@ -99,12 +150,12 @@ pub const App = struct {
                 .label = label,
                 .deletable = !c.isRunning(),
                 .selected = false,
+                .status = if (c.isRunning()) .running else .exited,
             };
         }
         self.container_list = list_mod.List.init(self.container_items, 20);
 
-        // イメージ
-        self.images = try docker.listImages();
+        // イメージ UI アイテムを構築
         self.image_items = try self.allocator.alloc(list_mod.SelectableItem, self.images.len);
         self.image_labels = try self.allocator.alloc([]u8, self.images.len);
         for (self.images, 0..) |img, i| {
@@ -121,12 +172,12 @@ pub const App = struct {
                 .label = label,
                 .deletable = true,
                 .selected = false,
+                .status = if (img.isDangling()) .warning else .normal,
             };
         }
         self.image_list = list_mod.List.init(self.image_items, 20);
 
-        // ボリューム
-        self.volumes = try docker.listVolumes();
+        // ボリューム UI アイテムを構築
         self.volume_items = try self.allocator.alloc(list_mod.SelectableItem, self.volumes.len);
         self.volume_labels = try self.allocator.alloc([]u8, self.volumes.len);
         for (self.volumes, 0..) |v, i| {
@@ -141,6 +192,7 @@ pub const App = struct {
                 .label = label,
                 .deletable = v.isOrphaned(),
                 .selected = false,
+                .status = if (v.isOrphaned()) .warning else .normal,
             };
         }
         self.volume_list = list_mod.List.init(self.volume_items, 20);
@@ -281,6 +333,14 @@ pub const App = struct {
             .volumes => 2,
         };
         try render.drawTabBar(w, &tab_names, active_idx, cols);
+
+        // カラムヘッダー
+        const header_text = switch (self.current_tab) {
+            .containers => "ID              NAME                            STATE       IMAGE",
+            .images => "ID              TAG                             SIZE",
+            .volumes => "NAME                            DRIVER",
+        };
+        try render.drawColumnHeader(w, header_text, cols);
 
         // リスト
         try self.currentList().draw(w, cols);

--- a/src/tui/list.zig
+++ b/src/tui/list.zig
@@ -10,6 +10,8 @@ pub const SelectableItem = struct {
     deletable: bool,
     /// 選択状態
     selected: bool,
+    /// 表示カラー用ステータス
+    status: @import("render.zig").ItemStatus = .normal,
 };
 
 /// チェックボックス付きリストウィジェット。
@@ -89,7 +91,15 @@ pub const List = struct {
         const render = @import("render.zig");
         const end = @min(self.scroll_offset + self.visible_rows, self.items.len);
         for (self.items[self.scroll_offset..end], self.scroll_offset..) |item, i| {
-            try render.drawListItem(writer, item.selected, i == self.cursor, item.label, cols);
+            try render.drawListItem(
+                writer,
+                item.selected,
+                i == self.cursor,
+                item.deletable,
+                item.status,
+                item.label,
+                cols,
+            );
         }
     }
 };

--- a/src/tui/render.zig
+++ b/src/tui/render.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 
 pub const RESET = "\x1b[0m";
 pub const BOLD = "\x1b[1m";
+pub const DIM = "\x1b[2m";
 pub const FG_BLACK = "\x1b[30m";
 pub const FG_RED = "\x1b[31m";
 pub const FG_GREEN = "\x1b[32m";
@@ -12,9 +13,24 @@ pub const FG_BLUE = "\x1b[34m";
 pub const FG_MAGENTA = "\x1b[35m";
 pub const FG_CYAN = "\x1b[36m";
 pub const FG_WHITE = "\x1b[37m";
+pub const FG_BRIGHT_BLACK = "\x1b[90m";
+pub const FG_BRIGHT_RED = "\x1b[91m";
+pub const FG_BRIGHT_GREEN = "\x1b[92m";
+pub const FG_BRIGHT_YELLOW = "\x1b[93m";
+pub const FG_BRIGHT_CYAN = "\x1b[96m";
+pub const FG_BRIGHT_WHITE = "\x1b[97m";
 pub const BG_BLACK = "\x1b[40m";
-pub const BG_WHITE = "\x1b[47m";
 pub const BG_BLUE = "\x1b[44m";
+pub const BG_WHITE = "\x1b[47m";
+pub const BG_DARK = "\x1b[100m"; // bright black = dark gray
+
+/// リストアイテムの表示状態。
+pub const ItemStatus = enum {
+    normal,
+    running, // 実行中コンテナ → 緑
+    exited, // 停止コンテナ → グレー
+    warning, // dangling image / orphaned volume → 黄
+};
 
 /// カーソルをホーム位置に移動して画面をクリアする。
 pub fn clearAndHome(writer: anytype) !void {
@@ -27,53 +43,93 @@ pub fn moveCursor(writer: anytype, row: usize, col: usize) !void {
 }
 
 /// タブバーを描画する。
-/// tabs: タブ名の配列、active: アクティブタブのインデックス、cols: 端末幅
 pub fn drawTabBar(writer: anytype, tabs: []const []const u8, active: usize, cols: usize) !void {
     _ = cols;
-    try writer.writeAll(BG_BLUE ++ FG_WHITE);
+    try writer.writeAll(BG_BLUE ++ FG_BRIGHT_WHITE);
     for (tabs, 0..) |tab, i| {
         if (i == active) {
-            try writer.print(" " ++ BOLD ++ "{s}" ++ RESET ++ BG_BLUE ++ FG_WHITE ++ " ", .{tab});
+            try writer.print(" " ++ BOLD ++ FG_BRIGHT_WHITE ++ "{s}" ++ RESET ++ BG_BLUE ++ FG_BRIGHT_WHITE ++ " ", .{tab});
         } else {
             try writer.print(" {s} ", .{tab});
         }
-        if (i + 1 < tabs.len) {
-            try writer.writeAll("|");
-        }
+        if (i + 1 < tabs.len) try writer.writeAll(" | ");
     }
-    try writer.writeAll(RESET ++ "\n");
+    try writer.writeAll(RESET ++ "\r\n");
+}
+
+/// カラムヘッダーを描画する。
+pub fn drawColumnHeader(writer: anytype, text: []const u8, cols: usize) !void {
+    _ = cols;
+    try writer.print(BOLD ++ FG_BRIGHT_BLACK ++ "    {s}" ++ RESET ++ "\r\n", .{text});
 }
 
 /// チェックボックス付きリスト行を描画する。
-/// checked: 選択済み、selected: カーソル位置、line: 行テキスト、cols: 端末幅
-pub fn drawListItem(writer: anytype, checked: bool, selected: bool, line: []const u8, cols: usize) !void {
+pub fn drawListItem(
+    writer: anytype,
+    checked: bool,
+    is_cursor: bool,
+    deletable: bool,
+    status: ItemStatus,
+    line: []const u8,
+    cols: usize,
+) !void {
     _ = cols;
-    const checkbox = if (checked) "[x]" else "[ ]";
-    if (selected) {
-        try writer.print(BG_BLUE ++ FG_WHITE ++ "{s} {s}" ++ RESET ++ "\n", .{ checkbox, line });
+
+    // チェックボックス文字列
+    const checkbox = if (checked) "[x]" else if (!deletable) "[-]" else "[ ]";
+
+    // チェックボックスの色
+    const cb_color = if (checked)
+        FG_BRIGHT_CYAN ++ BOLD
+    else if (!deletable)
+        FG_BRIGHT_BLACK
+    else
+        FG_WHITE;
+
+    // ラベルの色
+    const label_color = switch (status) {
+        .running => FG_BRIGHT_GREEN,
+        .exited => FG_BRIGHT_BLACK,
+        .warning => FG_BRIGHT_YELLOW,
+        .normal => FG_WHITE,
+    };
+
+    if (is_cursor) {
+        // カーソル行: ダークグレー背景 + 行末まで塗りつぶし
+        try writer.writeAll(BG_DARK);
+        try writer.print(" {s}{s}" ++ RESET ++ BG_DARK ++ " {s}{s}" ++ RESET ++ "\x1b[K\r\n", .{
+            cb_color, checkbox, label_color, line,
+        });
     } else {
-        try writer.print("{s} {s}\n", .{ checkbox, line });
+        try writer.print(" {s}{s}" ++ RESET ++ " {s}{s}" ++ RESET ++ "\r\n", .{
+            cb_color, checkbox, label_color, line,
+        });
     }
 }
 
 /// ステータスバーを描画する。
 pub fn drawStatusBar(writer: anytype, text: []const u8, cols: usize) !void {
     _ = cols;
-    try writer.print(BG_BLACK ++ FG_WHITE ++ " {s} " ++ RESET ++ "\n", .{text});
+    try writer.print(BG_BLACK ++ FG_BRIGHT_WHITE ++ BOLD ++ " {s} " ++ RESET ++ "\r\n", .{text});
 }
 
 /// ヘルプバーを描画する。
 pub fn drawHelpBar(writer: anytype, cols: usize) !void {
     _ = cols;
-    try writer.writeAll(BG_BLACK ++ FG_WHITE ++
-        " j/k:move  Space:select  Tab:tab  a:all  d:delete  q:quit" ++
-        RESET ++ "\n");
+    try writer.writeAll(
+        FG_BRIGHT_BLACK ++
+            " j/k:↑↓  Space:select  Tab:tab  a:all  d:delete  q:quit" ++
+            RESET ++ "\r\n",
+    );
 }
 
 /// 確認ダイアログを画面中央に描画する。
 pub fn drawConfirmDialog(writer: anytype, count: usize, size_str: []const u8, rows: usize, cols: usize) !void {
     const dialog_row = rows / 2 - 2;
-    const dialog_col = if (cols > 50) (cols - 50) / 2 else 1;
+    const dialog_col = if (cols > 52) (cols - 52) / 2 else 1;
     try moveCursor(writer, dialog_row, dialog_col);
-    try writer.print(BOLD ++ "Delete {d} item(s) ({s})? [Enter/Esc]" ++ RESET, .{ count, size_str });
+    try writer.print(
+        BOLD ++ FG_BRIGHT_YELLOW ++ "  Delete {d} item(s) ({s})? [Enter/Esc]  " ++ RESET,
+        .{ count, size_str },
+    );
 }

--- a/tests/render_test.zig
+++ b/tests/render_test.zig
@@ -39,7 +39,7 @@ test "drawTabBar highlights active tab with bold" {
 test "drawListItem includes item text" {
     var buf: [512]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buf);
-    try render.drawListItem(fbs.writer(), false, false, "my-container  nginx  running", 80);
+    try render.drawListItem(fbs.writer(), false, false, true, .normal, "my-container  nginx  running", 80);
     const out = fbs.getWritten();
     try std.testing.expect(std.mem.indexOf(u8, out, "my-container") != null);
 }
@@ -47,7 +47,7 @@ test "drawListItem includes item text" {
 test "drawListItem shows checkbox unchecked" {
     var buf: [512]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buf);
-    try render.drawListItem(fbs.writer(), false, false, "item", 80);
+    try render.drawListItem(fbs.writer(), false, false, true, .normal, "item", 80);
     const out = fbs.getWritten();
     try std.testing.expect(std.mem.indexOf(u8, out, "[ ]") != null);
 }
@@ -55,7 +55,7 @@ test "drawListItem shows checkbox unchecked" {
 test "drawListItem shows checkbox checked" {
     var buf: [512]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buf);
-    try render.drawListItem(fbs.writer(), true, false, "item", 80);
+    try render.drawListItem(fbs.writer(), true, false, true, .normal, "item", 80);
     const out = fbs.getWritten();
     try std.testing.expect(std.mem.indexOf(u8, out, "[x]") != null);
 }


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## レビューに関して
レビューする際には、以下のprefix(接頭辞)を付けましょう。

[must] → かならず変更してね
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)
[nits] → ささいな指摘(nitpick)
[ask] → 質問
[fyi] → 参考情報

## Issues No
関連Issueなし（バグ修正・改善）

## 概要
`dk` コマンドで発生していた起動不能・数十秒ハング・表示崩れを修正し、TUIのカラー表示と列ヘッダーを追加。

## 変更内容
### 追加機能
- [x] TUIにカラムヘッダー追加（ID/NAME/STATE/IMAGE等）
- [x] ステータス別カラー表示（running=緑 / exited=グレー / dangling/orphaned=黄）
- [x] チェックボックス色分け（選択=[x]シアン / 削除不可=[-]グレー）
- [x] containers/images/volumes の並列API呼び出し（std.Thread）

### 修正内容
- [x] **クリティカル**: Docker APIがHTTP/1.1でChunked Transfer Encodingを返すのに未デコードで `UnexpectedToken` エラー
- [x] **クリティカル**: `Connection: keep-alive` でEOFを待ち続ける数十秒ハング → レスポンス完結検知（`\r\n0\r\n\r\n`）で即時終了
- [x] TUI raw モードで `\n` のみ使用により列がずれる問題 → `\r\n` に修正
- [x] `size=true` パラメータによる不要なサイズ計算の削除（高速化）
- [x] バイナリ名 `dkill` → `dk` に変更

### その他の変更
- [x] リファクタリング: `client.zig` に `isResponseComplete`・`isChunked`・`decodeChunked`・`getContentLength` を追加

## 動作確認手順
1. ビルド
   ```bash
   zig build
   sudo cp zig-out/bin/dk /usr/local/bin/dk
   ```

2. 確認手順
   - [x] `dk` 起動後、即座にTUIが表示される（数十秒ハングなし）
   - [x] containers/images/volumes タブが正しく表示される
   - [x] 列が正しく揃っている
   - [x] running=緑 / exited=グレー / dangling=黄 で色分け表示
   - [x] `j/k` 移動、`Space` 選択、`Tab` タブ切り替えが動作する

## テスト
- [ ] 単体テストを追加・更新しました
- [ ] 統合テストを追加・更新しました
- [x] 手動テストを実施しました

### テスト実行結果
```bash
zig build test
```

## 品質チェック
- [x] 不要なコメントやデバッグコードを削除

## スクリーンショット（UI変更がある場合）
Before:
- 列がずれて読めない
- 色なし
- 起動に数十秒かかる or エラー

After:
- 列が揃ったヘッダー付きリスト
- running=緑、exited=グレー、カーソル行=ダークグレー背景
- 即座に起動

## 破壊的変更
- [x] バイナリ名が `dkill` から `dk` に変更（インストール済みの場合は再インストールが必要）