### PR TITLE
fix: HTTP chunked encoding対応・TUI高速化・カラー表示改善・CI修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,86 @@
-# dkill
+# dk
+
+Docker リソースをインタラクティブに管理する TUI ツール。
+コンテナ・イメージ・ボリュームの一覧表示と削除を高速に行えます。
+
+## 特徴
+
+- **インタラクティブ TUI** — カラー表示のチェックボックス付きリストで複数リソースを選択して一括削除
+- **CLI サブコマンド** — スクリプトやパイプラインから利用可能なコマンドライン操作
+- **軽量・高速** — Zig 製のシングルバイナリ、バイナリサイズ 1MB 未満
+- **並列取得** — コンテナ・イメージ・ボリュームを並列に取得して高速起動
+
+## インストール
+
+```sh
+git clone https://github.com/AI1411/dkill.git
+cd dkill
+zig build -Doptimize=ReleaseSmall
+sudo cp zig-out/bin/dk /usr/local/bin/
+```
+
+## 使い方
+
+### TUI モード（引数なし）
+
+```sh
+dk
+```
+
+| キー | 操作 |
+|------|------|
+| `j` / `k` | カーソル移動 |
+| `↑` / `↓` | カーソル移動 |
+| `Space` | 選択 / 選択解除 |
+| `a` | 削除可能な全アイテムを選択 |
+| `Tab` | タブ切り替え（Containers / Images / Volumes） |
+| `d` | 選択アイテムを削除 |
+| `q` / `Ctrl-C` | 終了 |
+
+### CLI サブコマンド
+
+```sh
+# コンテナ一覧
+dk containers
+dk containers --exited          # 停止コンテナのみ
+dk containers --json            # JSON 出力
+
+# イメージ一覧
+dk images
+dk images --dangling            # dangling イメージのみ
+dk images --json
+
+# ボリューム一覧
+dk volumes
+dk volumes --orphaned           # 孤立ボリュームのみ
+dk volumes --json
+
+# ディスク使用量サマリー
+dk df
+
+# 未使用リソースを一括削除
+dk prune --all                  # 全未使用リソース
+dk prune --containers           # 停止コンテナのみ
+dk prune --images-dangling      # dangling イメージのみ
+dk prune --volumes-orphaned     # 孤立ボリュームのみ
+dk prune --all --yes            # 確認スキップ
+dk prune --all --dry-run        # 削除対象を表示のみ（実削除なし）
+```
+
+## ビルド要件
+
+- [Zig](https://ziglang.org/) 0.15.2 以上
+- Docker が `/var/run/docker.sock` で稼働していること
+
+## 開発
+
+```sh
+# ビルド
+zig build
+
+# テスト（Docker 不要）
+SKIP_DOCKER_TESTS=1 zig build test
+
+# テスト（Docker あり）
+zig build test
+```


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## レビューに関して
レビューする際には、以下のprefix(接頭辞)を付けましょう。
[must] → かならず変更してね
[imo] → 自分の意見だとこうだけど修正必須ではないよ
[nits] → ささいな指摘
[ask] → 質問
[fyi] → 参考情報

## Issues No
close #16 #17 #18 #19 #20

## 概要
`dk` コマンド起動時の `UnexpectedToken` エラー、数十秒かかるパフォーマンス問題、TUI の表示崩れを修正。CI の Zig インストール失敗も修正した。

## 変更内容
### 追加機能
- [x] TUI にカラー表示追加（実行中コンテナ=緑、停止=グレー、dangling/orphaned=黄色）
- [x] TUI にカラムヘッダー追加（ID / NAME / STATE / IMAGE など）
- [x] コンテナ・イメージ・ボリュームの並列取得（3スレッド同時取得）

### 修正内容
- [x] Docker API レスポンスの Chunked Transfer Encoding デコード未対応を修正（`UnexpectedToken` の原因）
- [x] `size=true` パラメータ除去によるパフォーマンス改善（数十秒 → 即時）
- [x] HTTP レスポンス完結判定の追加（チャンク終端 `\r\n0\r\n\r\n` 検出で即終了）
- [x] TUI の行末改行を `\r\n` に統一（raw モードでのカラム崩れ修正）
- [x] バイナリ名を `dkill` から `dk` に変更

### その他の変更
- [x] `parseHttpResponse` 公開関数を追加（テスト用）
- [x] `drawListItem` のシグネチャを拡張（`deletable`・`status` 引数追加）
- [x] テストを新しい関数シグネチャに合わせて更新
- [x] CI の Zig インストールを `mlugg/setup-zig` から直接ダウンロードに変更
- [x] Zig バージョンを 0.15.2 に更新（ファイル名形式 `zig-x86_64-linux-0.15.2.tar.xz`）
- [x] README を全面更新（TUI キーバインド・CLI コマンド全一覧・インストール手順）

## 動作確認手順
1. 環境構築
   ```bash
   zig build
   sudo cp zig-out/bin/dk /usr/local/bin/
   ```

2. 確認手順
   - [x] 手順1: `dk` でTUIが即起動すること（数十秒待たなくてよい）
   - [x] 手順2: TUI でコンテナ・イメージ・ボリュームがカラー表示されること
   - [x] 手順3: `dk containers` / `dk images` / `dk volumes` でリストが表示されること
   - [x] 手順4: `dk prune --all --dry-run` で削除対象が表示されること

## テスト
- [x] 単体テストを追加・更新しました
- [ ] 統合テストを追加・更新しました
- [x] 手動テストを実施しました

### テスト実行結果
```bash
SKIP_DOCKER_TESTS=1 zig build test
# → 全テスト合格
```

## 品質チェック
- [x] `zig build` でコンパイルエラーなし
- [x] `SKIP_DOCKER_TESTS=1 zig build test` で全テスト合格
- [x] `zig build -Doptimize=ReleaseSmall` でバイナリサイズ 1MB 未満を確認
- [x] 不要なコメントやデバッグコードを削除

## マイグレーション（DBスキーマ変更がある場合）
該当なし

## スクリーンショット（UI変更がある場合）
Before: 列がズレた単色表示、起動に数十秒
After: カラムヘッダー付きカラー表示、即時起動

## 破壊的変更
- バイナリ名が `dkill` → `dk` に変わります